### PR TITLE
避免偶发的点击错误

### DIFF
--- a/src/weixin/index.ts
+++ b/src/weixin/index.ts
@@ -121,7 +121,9 @@ export async function jumpToConfirmPage() {
   const nextStepBtn = await page.waitForSelector('.code_submit_dialog .weui-desktop-btn.weui-desktop-btn_primary')
   if (!agreeCheckbox || !nextStepBtn)
     throw new Error('未找阅读并了解平台审核规则')
+  await sleep(1000)
   await agreeCheckbox.click()
+  await sleep(1000)
   await nextStepBtn.click()
 
   // 代码审核进行安全测试提醒, 操作继续提交


### PR DESCRIPTION
某些固定的微信小程序执行提交审核的过程会一直抛这样的错，猜测是modal的过渡动画导致，多sleep 1秒解决。

```
✔ 扫码成功
⠦ 正在跳转到版本管理页面...click submitReviewBtn
⠙ 正在跳转到版本管理页面...click agreeCheckbox
Error: Node is either not clickable or not an Element
    at CdpElementHandle.clickablePoint
```